### PR TITLE
Update appveyor and coveralls to point to our project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # Address Book (Level 4)
 
 [![Build Status](https://travis-ci.org/CS2103JAN2017-T11-B4/main.svg?branch=master)](https://travis-ci.org/CS2103JAN2017-T11-B4/main)
-[![Build status](https://ci.appveyor.com/api/projects/status/3boko2x2vr5cc3w2?svg=true)](https://ci.appveyor.com/project/damithc/addressbook-level4)
-[![Coverage Status](https://coveralls.io/repos/github/se-edu/addressbook-level4/badge.svg?branch=master)](https://coveralls.io/github/se-edu/addressbook-level4?branch=master)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/fc0b7775cf7f4fdeaf08776f3d8e364a)](https://www.codacy.com/app/damith/addressbook-level4?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=se-edu/addressbook-level4&amp;utm_campaign=Badge_Grade)
+[![Build status](https://ci.appveyor.com/api/projects/status/577pgluuyspav7bx?svg=true)](https://ci.appveyor.com/project/evanyeung/main)
+[![Coverage Status](https://coveralls.io/repos/github/CS2103JAN2017-T11-B4/main/badge.svg)](https://coveralls.io/github/CS2103JAN2017-T11-B4/main)
 
 <img src="docs/images/Ui.png" width="600"><br>
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Address Book (Level 4)
+# DoTomorrow
 
 [![Build Status](https://travis-ci.org/CS2103JAN2017-T11-B4/main.svg?branch=master)](https://travis-ci.org/CS2103JAN2017-T11-B4/main)
 [![Build status](https://ci.appveyor.com/api/projects/status/577pgluuyspav7bx?svg=true)](https://ci.appveyor.com/project/evanyeung/main)


### PR DESCRIPTION
We don't seem to use the codacy badge so I removed it for now. We can add it back in later if required/we find it useful.