### PR TITLE
Add taskId to TaskMemento

### DIFF
--- a/src/main/java/seedu/task/logic/history/TaskMemento.java
+++ b/src/main/java/seedu/task/logic/history/TaskMemento.java
@@ -2,6 +2,7 @@
 package seedu.task.logic.history;
 
 import seedu.task.model.task.Task;
+import seedu.task.model.task.TaskId;
 
 /**
  * A memento contains the information to restore the system to some state. In this case, it
@@ -9,16 +10,36 @@ import seedu.task.model.task.Task;
  * Task. The Task ID may be used to match up the memento's task with that in the Task list.
  */
 public class TaskMemento {
+    public final TaskId taskId;
     public final Task task;
 
     public TaskMemento(Task task) {
+        assert task != null;
         this.task = task;
+        this.taskId = task.getTaskId();
+    }
+
+    public TaskMemento(Task task, TaskId taskId) {
+        assert taskId != null;
+        this.task = task;
+        this.taskId = taskId;
     }
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof TaskMemento // instanceof handles nulls
-                && this.task.equals(((TaskMemento) other).task));
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof TaskMemento)) { // instanceof handles nulls
+            return false;
+        }
+
+        boolean isTaskEqual = this.task == null ?
+                ((TaskMemento) other).task == null :
+                this.task.equals(((TaskMemento) other).task);
+
+        boolean isTaskIdEqual = this.taskId.equals(((TaskMemento) other).taskId);
+
+        return isTaskEqual && isTaskIdEqual;
     }
 }

--- a/src/test/java/seedu/test/logic/history/TaskMementoTest.java
+++ b/src/test/java/seedu/test/logic/history/TaskMementoTest.java
@@ -50,6 +50,12 @@ public class TaskMementoTest {
                                                         duration,
                                                         new UniqueTagList("Other"), id));
         assertFalse(memento1.equals(memento6));
+
+        TaskMemento memento7 = new TaskMemento(null, id);
+        TaskMemento memento8 = new TaskMemento(null, id);
+        assertTrue(memento7.equals(memento8));
+        TaskMemento memento9 = new TaskMemento(null, new TaskId(101));
+        assertFalse(memento7.equals(memento9));
     }
 
 }


### PR DESCRIPTION
There are cases when the task memento might be null. We still need a reference to the ID in this case.