### PR TITLE
Make TaskMementos a singleton

### DIFF
--- a/src/main/java/seedu/task/logic/history/TaskMementos.java
+++ b/src/main/java/seedu/task/logic/history/TaskMementos.java
@@ -8,12 +8,20 @@ import java.util.Stack;
  * Stores a history of tasks. Can be used to implement undo/redo histories.
  */
 public class TaskMementos {
+    private static TaskMementos taskMementos;
     private Stack<TaskMemento> undoMementoStack;
     private Stack<TaskMemento> redoMementoStack;
 
-    public TaskMementos() {
+    private TaskMementos() {
         this.undoMementoStack = new Stack<TaskMemento>();
         this.redoMementoStack = new Stack<TaskMemento>();
+    }
+
+    public static TaskMementos getInstance() {
+        if (taskMementos == null) {
+            TaskMementos.taskMementos = new TaskMementos();
+        }
+        return TaskMementos.taskMementos;
     }
 
     /**
@@ -51,5 +59,14 @@ public class TaskMementos {
         TaskMemento memento = redoMementoStack.pop();
         undoMementoStack.push(memento);
         return Optional.of(memento);
+    }
+
+    /**
+     * This is a potentially dangerous method that clears both the undo and redo stacks.
+     * It was created initially to enable testing of a singleton class.
+     */
+    public void reset() {
+        this.redoMementoStack.clear();
+        this.undoMementoStack.clear();
     }
 }

--- a/src/test/java/seedu/test/logic/history/TaskMementosTest.java
+++ b/src/test/java/seedu/test/logic/history/TaskMementosTest.java
@@ -50,8 +50,20 @@ public class TaskMementosTest {
     }
 
     @Test
+    public void resetTest() {
+        TaskMementos mementos = TaskMementos.getInstance();
+        mementos.addUndoMementoAndClearRedo(memento1);
+        mementos.addUndoMementoAndClearRedo(memento2);
+        mementos.getUndoMemento();
+        mementos.reset();
+        assertEquals(Optional.empty(), mementos.getUndoMemento());
+        assertEquals(Optional.empty(), mementos.getRedoMemento());
+    }
+
+    @Test
     public void undoTest() {
-        TaskMementos mementos = new TaskMementos();
+        TaskMementos mementos = TaskMementos.getInstance();
+        mementos.reset();
         assertEquals(Optional.empty(), mementos.getUndoMemento());
         mementos.addUndoMementoAndClearRedo(memento1);
         assertEquals(Optional.of(memento1), mementos.getUndoMemento());
@@ -60,7 +72,8 @@ public class TaskMementosTest {
 
     @Test
     public void redoTest() {
-        TaskMementos mementos = new TaskMementos();
+        TaskMementos mementos = TaskMementos.getInstance();
+        mementos.reset();
         assertEquals(Optional.empty(), mementos.getRedoMemento());
         mementos.addUndoMementoAndClearRedo(memento1);
         assertEquals(Optional.empty(), mementos.getRedoMemento());
@@ -72,7 +85,8 @@ public class TaskMementosTest {
 
     @Test
     public void multipleUndoRedoTest() {
-        TaskMementos mementos = new TaskMementos();
+        TaskMementos mementos = TaskMementos.getInstance();
+        mementos.reset();
         assertEquals(Optional.empty(), mementos.getUndoMemento());
         assertEquals(Optional.empty(), mementos.getRedoMemento());
         mementos.addUndoMementoAndClearRedo(memento1);


### PR DESCRIPTION
TaskMementos needs to be shared among multiple commands with the same
data. Making it a singleton to allow multiple classes to access the same
instance.